### PR TITLE
Add optional getScope and getPrompt configuration functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,31 @@ checkins:
     app.get('/auth/google',
       passport.authenticate('google-openidconnect', { scope: ['email', 'profile'] }));
 
-You doesn't need to contain the scope of `openid`, added by this module automatically
+Your array of scopes doesn't need to contain the scope of `openid`, since it added by this module automatically
 
+## Dynamic Scope Requests
+
+If you need to be able to modify which scopes are requested based on the user, then you can pass a `getScpe` function that accepts a request object as its paramter and syncrhronously returns a space-seperated string of quotes
+
+    var StrategyGoogle = require('passport-google-openidconnect').Strategy;
+    passport.use(new StrategyGoogle({
+        clientID: GOOGLE_CLIENT_ID,
+        clientSecret: GOOGLE_CLIENT_SECRET,
+        callbackURL: "http://127.0.0.1:3000/auth/google/callback",
+        userInfoURL: "https://www.googleapis.com/plus/v1/people/me"
+        getScope: function (req) {
+          // pass the scope query param used from the login page 
+          // along to Google
+          var requestedScopes = req.query.scopes
+          return requestedScopes
+        }
+      },
+      function(iss, sub, profile, accessToken, refreshToken, done) {
+        User.findOrCreate({ googleId: profile.id }, function (err, user) {
+          return done(err, user);
+        });
+      }
+    ));
 
 ## Usage for non Google+ and only openid
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Your array of scopes doesn't need to contain the scope of `openid`, since it add
 
 ## Dynamic Scope Requests
 
-If you need to be able to modify which scopes are requested based on the user, then you can pass a `getScpe` function that accepts a request object as its paramter and syncrhronously returns a space-seperated string of quotes
+If you need to be able to modify which scopes are requested based on the user/request, then you can pass a `getScope` function when configuring the strategy. The getScope function accepts a request object as its only parameter and syncrhronously returns a space-seperated string of scopes
 
     var StrategyGoogle = require('passport-google-openidconnect').Strategy;
     passport.use(new StrategyGoogle({

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -10,7 +10,7 @@ var passport = require('passport')
   , setup = require('./setup')
   , InternalOAuthError = require('./errors/internaloautherror');
 
-var log_verbose = false;
+var log_verbose = true;
 
 /**
  * `Strategy` constructor.

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -443,6 +443,9 @@ Strategy.prototype.authorizationParams = function(options) {
   if (options.hd) {
     params['hd'] = options.hd;
   }
+  if (options.includeGrantedScopes) {
+    params['include_granted_scopes'] = options.includeGrantedScopes
+  }
   return params;
 }
 

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -27,14 +27,14 @@ function Strategy(options, verify) {
   passport.Strategy.call(this);
   this.name = 'google-openidconnect';
   this._verify = verify;
-  
+
   // TODO: What's the recommended field name for OpenID Connect?
   this._identifierField = options.identifierField || 'openid_identifier';
   this._scope = options.scope;
   this._scopeSeparator = options.scopeSeparator || ' ';
   this._passReqToCallback = options.passReqToCallback;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
-  
+
   this._configurers = [];
 
   // https://accounts.google.com/.well-known/openid-configuration
@@ -80,23 +80,23 @@ util.inherits(Strategy, passport.Strategy);
 Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
   var self = this;
-  
+
   if (req.query && req.query.error) {
     // TODO: Error information pertaining to OAuth 2.0 flows is encoded in the
     //       query parameters, and should be propagated to the application.
     return this.fail();
   }
-  
-  
+
+
   if (req.query && req.query.code) {
     var code = req.query.code;
-    
+
     this.configure(null, function(err, config) {
       if (err) { return self.error(err); }
-    
+
       var oauth2 = new OAuth2(config.clientID,  config.clientSecret,
                               '', config.authorizationURL, config.tokenURL);
-                              
+
       var callbackURL = options.callbackURL || config.callbackURL;
       if (callbackURL) {
         var parsed = url.parse(callbackURL);
@@ -106,7 +106,7 @@ Strategy.prototype.authenticate = function(req, options) {
           callbackURL = url.resolve(utils.originalURL(req), callbackURL);
         }
       }
-      
+
       oauth2.getOAuthAccessToken(code, { grant_type: 'authorization_code', redirect_uri: callbackURL }, function(err, accessToken, refreshToken, params) {
         if (err) { return self.error(new InternalOAuthError('failed to obtain access token', err)); }
 
@@ -121,11 +121,11 @@ Strategy.prototype.authenticate = function(req, options) {
 
         var idToken = params['id_token'];
         if (!idToken) { return self.error(new Error('ID Token not present in token response')); }
-        
+
         var idTokenSegments = idToken.split('.')
           , jwtClaimsStr
           , jwtClaims;
-        
+
         try {
           jwtClaimsStr = new Buffer(idTokenSegments[1], 'base64').toString();
           jwtClaims = JSON.parse(jwtClaimsStr);
@@ -146,7 +146,7 @@ Strategy.prototype.authenticate = function(req, options) {
         if (!sub) {
           sub = jwtClaims.user_id;
         }
-        
+
         // ID Token Validation
         //   http://openid.net/specs/openid-connect-basic-1_0.html#rfc.section.2.2.1
 
@@ -178,13 +178,13 @@ Strategy.prototype.authenticate = function(req, options) {
 
         self._shouldLoadUserProfile(iss, sub, function(err, load) {
           if (err) { return self.error(err); };
-          
+
           if (load) {
             var parsed = url.parse(config.userInfoURL, true);
             parsed.query['schema'] = 'openid';
             delete parsed.search;
             var userInfoURL = url.format(parsed);
-            
+
             // NOTE: We are calling node-oauth's internal `_request` function (as
             //       opposed to `get`) in order to send the access token in the
             //       `Authorization` header rather than as a query parameter.
@@ -195,7 +195,7 @@ Strategy.prototype.authenticate = function(req, options) {
             //       Setting the fifth argument of `_request` to `null` works
             //       around this issue.  I've noted this in comments here:
             //       https://github.com/ciaranj/node-oauth/issues/117
-            
+
             //oauth2.get(userInfoURL, accessToken, function (err, body, res) {
             oauth2._request("GET", userInfoURL, { 'Authorization': "Bearer " + accessToken, 'Accept': "application/json" }, null, null, function (err, body, res) {
               if (err) { return self.error(new InternalOAuthError('failed to fetch user profile', err)); }
@@ -208,10 +208,10 @@ Strategy.prototype.authenticate = function(req, options) {
               }
 
               var profile = {};
-              
+
               try {
                 var json = JSON.parse(body);
-                
+
                 profile.id = json.sub;
                 // Prior to OpenID Connect Basic Client Profile 1.0 - draft 22, the
                 // "sub" key was named "user_id".  Many providers still use the old
@@ -219,15 +219,15 @@ Strategy.prototype.authenticate = function(req, options) {
                 if (!profile.id) {
                   profile.id = json.user_id;
                 }
-                
+
                 profile.displayName = json.name;
                 profile.name = { familyName: json.family_name,
                                  givenName: json.given_name,
                                  middleName: json.middle_name };
-                
+
                 profile._raw = body;
                 profile._json = json;
-                
+
                 onProfileLoaded(profile);
               } catch(ex) {
                 return self.error(ex);
@@ -238,14 +238,14 @@ Strategy.prototype.authenticate = function(req, options) {
             profile.id = sub;
             onProfileLoaded(profile);
           }
-          
+
           function onProfileLoaded(profile) {
             function verified(err, user, info) {
               if (err) { return self.error(err); }
               if (!user) { return self.fail(info); }
               self.success(user, info);
             }
-          
+
             if (self._passReqToCallback) {
               var arity = self._verify.length;
               if (arity == 9) {
@@ -274,7 +274,7 @@ Strategy.prototype.authenticate = function(req, options) {
               }
             }
           }
-          
+
         });
       });
     });
@@ -284,17 +284,17 @@ Strategy.prototype.authenticate = function(req, options) {
     // be loaded.  The configuration is typically either pre-configured or
     // discovered dynamically.  When using dynamic discovery, a user supplies
     // their identifer as input.
-  
+
     var identifier;
     if (req.body && req.body[this._identifierField]) {
       identifier = req.body[this._identifierField];
     } else if (req.query && req.query[this._identifierField]) {
       identifier = req.query[this._identifierField];
     }
-  
+
     this.configure(identifier, function(err, config) {
       if (err) { return self.error(err); }
-      
+
       var callbackURL = options.callbackURL || config.callbackURL;
       if (callbackURL) {
         var parsed = url.parse(callbackURL);
@@ -304,7 +304,7 @@ Strategy.prototype.authenticate = function(req, options) {
           callbackURL = url.resolve(utils.originalURL(req), callbackURL);
         }
       }
-      
+
       var params = self.authorizationParams(options);
       params['response_type'] = 'code';
       params['client_id'] = config.clientID;
@@ -315,6 +315,21 @@ Strategy.prototype.authenticate = function(req, options) {
         params.scope = 'openid' + self._scopeSeparator + scope;
       } else {
         params.scope = 'openid';
+      }
+
+      // allow the user to provide a function that dynamically sets the scope
+      if (typeof self._getScope === 'function') {
+        var dynamicScope = self._getScope(req, options);
+        if (dynamicScope) {
+          params.scope = dynamicScope
+        }
+      }
+      // allow the user to provide a function that dynamically sets the prompt
+      if (typeof self._getPrompt === 'function') {
+        var dynamicPrompt = self._getPrompt(req, options);
+        if (dynamicPrompt) {
+          params.prompt = dynamicPrompt;
+        }
       }
 
       var location = config.authorizationURL + '?' + querystring.stringify(params);
@@ -356,7 +371,7 @@ Strategy.prototype.configure = function(identifier, done) {
   (function pass(i, err, config) {
     // an error or configuration was obtained, done
     if (err || config) { return done(err, config); }
-    
+
     var layer = stack[i];
     if (!layer) {
       // Strategy-specific functions did not result in obtaining configuration
@@ -364,7 +379,7 @@ Strategy.prototype.configure = function(identifier, done) {
       // to discover the provider's configuration.
       return setup(identifier, done);
     }
-    
+
     try {
       layer(identifier, function(e, c) { pass(i + 1, e, c); } )
     } catch (ex) {
@@ -477,5 +492,5 @@ Strategy.prototype.revoke = function(options, done) {
 
 /**
  * Expose `Strategy`.
- */ 
+ */
 module.exports = Strategy;

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -33,6 +33,8 @@ function Strategy(options, verify) {
   this._scope = options.scope;
   this._getScope = options.getScope;
   this._getPrompt = options.getPrompt;
+  this._getAccessType = options.getAccessType;
+  this._getState = options.getState
   this._scopeSeparator = options.scopeSeparator || ' ';
   this._passReqToCallback = options.passReqToCallback;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;
@@ -319,18 +321,32 @@ Strategy.prototype.authenticate = function(req, options) {
         params.scope = 'openid';
       }
 
-      // allow the user to provide a function that dynamically sets the scope
+      // allow the user to provide a function that dynamically overrides the scope
       if (typeof self._getScope === 'function') {
         var dynamicScope = self._getScope(req, options);
         if (dynamicScope) {
           params.scope = dynamicScope
         }
       }
-      // allow the user to provide a function that dynamically sets the prompt
+      // allow the user to provide a function that dynamically overrides the prompt
       if (typeof self._getPrompt === 'function') {
         var dynamicPrompt = self._getPrompt(req, options);
         if (dynamicPrompt) {
           params.prompt = dynamicPrompt;
+        }
+      }
+      // allow the user to provide a function that dynamically overrides the access type
+      if (typeof self._getAccessType === 'function') {
+        var accessType = self._getAccessType(req, options);
+        if (accessType) {
+          params.access_type = accessType
+        }
+      }
+      // allow the user to provide a function that dynamically overrides the state
+      if (typeof self._getState === 'function') {
+        var state = self._getState(req, options);
+        if (state) {
+          params.state = state
         }
       }
 

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -31,6 +31,8 @@ function Strategy(options, verify) {
   // TODO: What's the recommended field name for OpenID Connect?
   this._identifierField = options.identifierField || 'openid_identifier';
   this._scope = options.scope;
+  this._getScope = options.getScope;
+  this._getPrompt = options.getPrompt;
   this._scopeSeparator = options.scopeSeparator || ' ';
   this._passReqToCallback = options.passReqToCallback;
   this._skipUserProfile = (options.skipUserProfile === undefined) ? false : options.skipUserProfile;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lever-passport-google-openidconnect",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Google OpenID Connect authentication strategy for Passport.",
   "keywords": [
     "passport",
@@ -35,10 +35,12 @@
       "email": "zeus@lever.co"
     }
   ],
-  "licenses": [ {
-    "type": "MIT",
-    "url": "http://www.opensource.org/licenses/MIT"
-  } ],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/MIT"
+    }
+  ],
   "main": "./lib",
   "dependencies": {
     "pkginfo": "0.2.x",
@@ -53,5 +55,7 @@
   "scripts": {
     "test": "NODE_PATH=./lib node_modules/.bin/mocha --reporter spec --require test/node/bootstrap test/*.test.js"
   },
-  "engines": { "node": ">= 0.6.0" }
+  "engines": {
+    "node": ">= 0.6.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "passport-google-openidconnect",
-  "version": "0.0.4",
+  "name": "lever-passport-google-openidconnect",
+  "version": "0.0.5",
   "description": "Google OpenID Connect authentication strategy for Passport.",
   "keywords": [
     "passport",
@@ -16,10 +16,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/kkkon/passport-google-openidconnect.git"
+    "url": "https://github.com/lever/passport-google-openidconnect.git"
   },
   "bugs": {
-    "url": "https://github.com/kkkon/passport-google-openidconnect/issues"
+    "url": "https://github.com/lever/passport-google-openidconnect/issues"
   },
   "author": {
     "name": "Kiyofumi Kondoh",
@@ -29,11 +29,15 @@
     {
       "name": "Jared Hanson",
       "email": "jaredhanson@gmail.com"
+    },
+    {
+      "name": "Zeus Lalkaka",
+      "email": "zeus@lever.co"
     }
   ],
   "licenses": [ {
     "type": "MIT",
-    "url": "http://www.opensource.org/licenses/MIT" 
+    "url": "http://www.opensource.org/licenses/MIT"
   } ],
   "main": "./lib",
   "dependencies": {


### PR DESCRIPTION
By allowing users to pass a function instead of a constant for the scope and prompt options, we are able to request different scope permissions from different users. 
